### PR TITLE
Update default settings to remove trailing comma

### DIFF
--- a/Settings/ToDone.sublime-settings
+++ b/Settings/ToDone.sublime-settings
@@ -26,5 +26,5 @@
     "color_scheme": "Packages/ToDone/Monokai_todone.hidden-tmTheme",
 
     // Spacing between the gutter and the text
-    "margin": 8,
+    "margin": 8
 }


### PR DESCRIPTION
On a fresh install of this plugin, the default .sublime-settings throws an error: 

Error trying to parse settings: Trailing comma before closing bracket in ~/Library/Application Support/Sublime Text 2/Packages/ToDone/Settings/ToDone.sublime-settings:30:1

To solve this I just removed the trailing comma.
